### PR TITLE
Set node parameters to private.

### DIFF
--- a/src/visensor_node.cpp
+++ b/src/visensor_node.cpp
@@ -34,14 +34,15 @@ int main(int argc, char** argv) {
 
   ros::init(argc, argv, "visensor_node");
   ros::NodeHandle nh;
+  ros::NodeHandle private_nh("~");
 
   //default sensor rates
   int cam_rate;
-  int imu_rate ;
+  int imu_rate;
 
   //Read values from ROS or set to default value
-  nh.param("imuRate", imu_rate, IMU_FREQUENCY);
-  nh.param("camRate", cam_rate, CAMERA_FREQUENCY);
+  private_nh.param("imuRate", imu_rate, IMU_FREQUENCY);
+  private_nh.param("camRate", cam_rate, CAMERA_FREQUENCY);
 
   visensor::ViSensor vi_sensor(nh);
   vi_sensor.startSensors(cam_rate, imu_rate);


### PR DESCRIPTION
@PascalGohl , @omaris 

Proper style with parameters is to have them in the private to the node, not the public namespace. :)
So you can edit them from the command line (_camRate:=5 will work) and they're in the correct place on the parameter server (i.e., /visensor_node/camRate, not /camRate). Currently in order to change the rate you have to set the global parameter and it's a pain.
