### PR TITLE
use same name for cfg header as cfg file to prevent rebuilding every time

### DIFF
--- a/cfg/visensor_node.cfg
+++ b/cfg/visensor_node.cfg
@@ -78,5 +78,5 @@ gen.add("cam3_coarse_shutter_width",       int_t,    0,    "shutter", 100,     2
 gen.add("cam3_adc_mode",       int_t,    0,    "ADC Mode", 2,2,3)
 gen.add("cam3_vref_adc_voltage_level",       int_t,    0,    "Vref ADC Voltage level", 4,0,7)
 
-exit(gen.generate(PACKAGE, "visensor_node", "Driver"))
+exit(gen.generate(PACKAGE, "visensor_node", "visensor_node"))
 

--- a/include/visensor.hpp
+++ b/include/visensor.hpp
@@ -45,7 +45,7 @@
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/fill_image.h>
 
-#include <visensor_node/DriverConfig.h>
+#include <visensor_node/visensor_nodeConfig.h>
 #include "visensor_node/visensor_imu.h"
 #include "visensor_node/visensor_time_host.h"
 #include "visensor_node/visensor_calibration_service.h"
@@ -103,7 +103,7 @@ class ViSensor {
   bool calibrationServiceCallback(visensor_node::visensor_calibration_service::Request &req,
                                   visensor_node::visensor_calibration_service::Response &res);
   //dynamic reconfigure callback
-  void configCallback(visensor_node::DriverConfig &config, uint32_t level);
+  void configCallback(visensor_node::visensor_nodeConfig &config, uint32_t level);
 
  private:
   void init();
@@ -135,9 +135,9 @@ class ViSensor {
 
   std::map<std::string, visensor_node::visensor_calibration> camera_imu_calibrations_;
 
-  dynamic_reconfigure::Server<visensor_node::DriverConfig> dr_srv_;
+  dynamic_reconfigure::Server<visensor_node::visensor_nodeConfig> dr_srv_;
 
-  visensor_node::DriverConfig config_;
+  visensor_node::visensor_nodeConfig config_;
 };
 
 }  //namespace visensor

--- a/src/visensor.cpp
+++ b/src/visensor.cpp
@@ -287,7 +287,7 @@ void ViSensor::frameCallback(ViFrame::Ptr frame_ptr, ViErrorCode error) {
       camera_imu_calibrations_[ROS_CAMERA_NAMES.at(static_cast<SensorId::SensorId>(frame_ptr->camera_id))]);
 }
 
-void ViSensor::configCallback(visensor_node::DriverConfig &config, uint32_t level) {
+void ViSensor::configCallback(visensor_node::visensor_nodeConfig &config, uint32_t level) {
 
   std::vector<SensorId::SensorId> all_available_sensor_ids = drv_.getListOfSensorIDs();
 


### PR DESCRIPTION
alternative solution to https://github.com/ethz-asl/visensor_node/pull/6
keeping the name of the cfg file prevents conflicts when having custom settings in there. 